### PR TITLE
Add SC congressional and senate district boundaries

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -20,6 +20,28 @@
           "url": "https://www2.census.gov/geo/tiger/TIGER2024/SLDL/tl_2024_45_sldl.zip",
           "districtField": "SLDLST",
           "file": "sldl.json"
+        },
+        {
+          "id": "federal:sc:congress",
+          "name": "SC Congressional Districts",
+          "source": "tiger",
+          "url": "https://www2.census.gov/geo/tiger/TIGER2024/CD/tl_2024_us_cd119.zip",
+          "districtField": "CD119FP",
+          "file": "cd.json",
+          "config": {
+            "stateFips": "45"
+          }
+        },
+        {
+          "id": "federal:sc:senate",
+          "name": "SC State Boundary (US Senate)",
+          "source": "tiger",
+          "url": "https://www2.census.gov/geo/tiger/TIGER2024/STATE/tl_2024_us_state.zip",
+          "districtField": "STUSPS",
+          "file": "state-outline.json",
+          "config": {
+            "stateFips": "45"
+          }
         }
       ],
       "jurisdictions": [

--- a/scrapers/boundaries.py
+++ b/scrapers/boundaries.py
@@ -291,17 +291,22 @@ def build_tiger(entry, output_path, dry_run=False):
     Build district boundaries from Census TIGER/Line shapefile.
 
     Args:
-        entry: Boundary entry dict with 'url', 'districtField', 'name'/'id'.
+        entry: Boundary entry dict with 'url', 'districtField', 'name'/'id',
+               and optional 'config.stateFips' to filter nationwide files.
         output_path: Path to write the output GeoJSON.
         dry_run: If True, print what would happen without downloading.
     """
     url = entry["url"]
     district_field = entry["districtField"]
     name = entry.get("name", entry.get("id", "unknown"))
+    config = entry.get("config", {})
+    state_fips_filter = config.get("stateFips")
 
     if dry_run:
         print(f"  Source: Census TIGER/Line shapefile")
         print(f"  Would download: {url}")
+        if state_fips_filter:
+            print(f"  Would filter to state FIPS: {state_fips_filter}")
         print(f"  Would write: {output_path}")
         return
 
@@ -314,8 +319,15 @@ def build_tiger(entry, output_path, dry_run=False):
             f"Available columns: {list(gdf.columns)}"
         )
 
-    # Filter to target state (should already be state-only, but verify)
-    if "STATEFP" in gdf.columns:
+    # Filter to target state if stateFips is configured (for nationwide files)
+    if state_fips_filter and "STATEFP" in gdf.columns:
+        gdf = gdf[gdf["STATEFP"] == str(state_fips_filter)]
+        print(f"  Filtered to state FIPS {state_fips_filter}: {len(gdf)} features")
+        if len(gdf) == 0:
+            raise RuntimeError(
+                f"No features found for state FIPS '{state_fips_filter}' in {name}"
+            )
+    elif "STATEFP" in gdf.columns:
         # Extract state FIPS from the data rather than hardcoding
         state_fips_values = gdf["STATEFP"].unique()
         if len(state_fips_values) > 1:


### PR DESCRIPTION
## Summary
This PR adds support for South Carolina's congressional and state senate districts by extending the boundary registry and enhancing the TIGER shapefile processor to handle nationwide datasets that need state-level filtering.

## Key Changes
- **Registry updates**: Added two new boundary entries for South Carolina:
  - `federal:sc:congress` - SC Congressional Districts (119th Congress)
  - `federal:sc:senate` - SC State Boundary for US Senate representation
  
- **Enhanced TIGER processor**: Modified `build_tiger()` function to support filtering nationwide shapefiles by state FIPS code:
  - Added optional `config.stateFips` configuration parameter to boundary entries
  - Implemented state-level filtering logic for nationwide files (e.g., Census CD and STATE files)
  - Added validation to ensure filtered results contain data
  - Maintains backward compatibility with existing state-specific shapefiles

## Implementation Details
- The new entries use nationwide Census TIGER files (`tl_2024_us_cd119.zip` and `tl_2024_us_state.zip`) rather than state-specific files
- State filtering is applied via the `STATEFP` column when `stateFips` is configured in the entry's config
- The processor now distinguishes between configured state filtering (for nationwide files) and automatic state detection (for state-specific files)
- Dry-run mode now displays the state FIPS filter when applicable

https://claude.ai/code/session_016vJzEwX2LvUo2MLapwiB5B