### PR TITLE
fix: harden scrape workflow and add missing urllib3 dependency

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -96,7 +96,9 @@ jobs:
           python scripts/quality_report.py > quality-report.md
           python scripts/quality_report.py --json > quality-report.json
           SUMMARY=$(python scripts/quality_report.py --summary-only)
-          echo "output=$SUMMARY" >> $GITHUB_OUTPUT
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$SUMMARY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Upload quality report
         if: always()
@@ -112,6 +114,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -e
+
           if git diff --quiet data/; then
             echo "No data changes detected"
             exit 0
@@ -121,7 +125,7 @@ jobs:
           git add data/
           BODY=$(python scripts/diff_summary.py --base HEAD --report scrape-report.json)
 
-          BRANCH="data-update/$(date +%Y-%m-%d-%H%M)"
+          BRANCH="data-update/$(date +%Y-%m-%d-%H%M%S)"
           git checkout -b "$BRANCH"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ beautifulsoup4>=4.12,<5
 geopandas>=1.0,<2
 pyyaml>=6.0,<7
 shapely>=2.0,<3
+urllib3>=1.26,<3


### PR DESCRIPTION
- Add urllib3 to requirements.txt (directly imported by anderson_city adapter)
- Use EOF delimiter for quality report output to handle multi-line safely
- Add set -e to PR creation shell block to catch failures early
- Add seconds to branch name to prevent minute-precision collisions

https://claude.ai/code/session_01CTxUYeBdrsfx9TPSUUZq4o