### PR TITLE
docs: update migration-guide for v0.2 schema

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -6,8 +6,10 @@ Instructions for replacing existing scraper infrastructure in DeflockSC and Call
 
 Two npm packages, updated weekly via automated scrapers:
 
-- **`open-civics`** — contact data (names, titles, emails, phones, districts, parties) for SC state legislators and 96 local jurisdictions
-- **`open-civics-boundaries`** — GeoJSON district boundaries for client-side point-in-polygon matching
+- **`open-civics`** — contact data for SC state legislators (senate + house + governor + lt-governor), 96 local jurisdictions (county and city councils), and federal representatives (US senators + US house members for SC)
+- **`open-civics-boundaries`** — GeoJSON district boundaries for client-side point-in-polygon matching (state legislative + county council + congressional + state outline)
+
+Starting in v0.2, every state-level and local-level member record carries structured seat fields (`office`, `seatClass`, `seatLabel`, `seatId`, `vacant`, etc.) so consumers don't need to parse free-text titles to find a constituent's representative. Federal records use a different shape (see below).
 
 ## Install
 
@@ -21,20 +23,63 @@ npm install open-civics open-civics-boundaries
 
 ```ts
 {
-  meta: { state: "SC", level: "state", lastUpdated: "2026-03-14" },
+  meta: { state: "SC", level: "state", lastUpdated: "2026-03-14", source: "openstates" },
   senate: {
-    [districtNumber: string]: {
-      name: string,
-      district: string,
-      party: "R" | "D",
-      email: string,
-      phone: string,
-      photoUrl?: string,
-      website?: string
-    }
+    [districtNumber: string]: StateMember
   },
-  house: { /* same shape */ },
-  governor: { name, title, email, phone, website }
+  house: {
+    [districtNumber: string]: StateMember
+  },
+  executive: ExecutiveMember[]   // governor, lt-governor
+}
+
+interface StateMember {
+  // identity + display
+  name: string;
+  title: string;                 // synthesized — e.g. "State Senator, District 25"
+  district: string;              // legacy alias of seatId, kept for v0.1 consumers
+
+  // structured seat (v0.2+)
+  office: "state-senator" | "state-representative";
+  leadership: null;              // state legislators don't carry leadership overlays in this dataset
+  seatClass: "numbered";
+  seatLabel: "district";
+  seatId: string;                // matches the dict key
+
+  // state
+  vacant: boolean;               // always false for legislators (vacancies don't get scraped into here)
+  seatSource: "source";          // structured from OpenStates CSV
+  partisan: true;
+  party: "R" | "D" | "I";
+
+  // contact
+  email: string;
+  emailVerified?: boolean;       // false when backfilled from name-based convention
+  phone: string;
+  photoUrl?: string;
+  website?: string;
+
+  // provenance
+  source: "openstates";
+  lastUpdated: string;
+}
+
+interface ExecutiveMember {
+  name: string;
+  title: string;                 // e.g. "Governor", "Lieutenant Governor"
+  office: "governor" | "lt-governor";
+  leadership: null;
+  seatClass: "at-large";
+  seatLabel: null;
+  seatId: null;
+  vacant: boolean;
+  seatSource: "source";
+  partisan: true;
+  email?: string;
+  phone?: string;
+  website?: string;
+  source: string;
+  lastUpdated: string;
 }
 ```
 
@@ -47,20 +92,92 @@ npm install open-civics open-civics-boundaries
     level: "local",
     jurisdiction: "county:greenville",  // or "place:greenville"
     label: "Greenville County Council",
-    lastUpdated: "2026-03-14"
-  },
-  members: [
-    {
-      name: string,
-      title: string,       // e.g. "Council Member, District 17"
+    lastUpdated: "2026-03-14",
+    adapter: "greenville_county",
+    dataHash: "...",
+    dataLastChanged: "...",
+    contact?: {                  // optional — when the council publishes no per-member contact
+      phone?: string,
       email?: string,
-      phone?: string
+      note?: string
     }
-  ]
+  },
+  members: LocalMember[]
+}
+
+interface LocalMember {
+  // identity + display
+  name: string;
+  title: string;                 // raw scraped string — e.g. "Council Member, District 17"
+
+  // structured seat (v0.2+)
+  office: "council-member" | "mayor";
+  leadership: "chair" | "vice-chair" | "mayor-pro-tem" | null;
+  seatClass: "numbered" | "at-large" | "unknown";
+  seatLabel: "district" | "ward" | "seat" | null;
+  seatId: string | null;
+
+  // state
+  vacant: boolean;
+  seatSource: "source" | "parsed-title" | "inferred-registry" | "manual";
+  partisan: boolean;             // false for most SC local offices
+
+  // contact
+  email?: string;
+  phone?: string;
+
+  // provenance
+  source: string;
+  lastUpdated: string;
 }
 ```
 
-Jurisdiction naming: `county-{name}.json` for counties, `place-{name}.json` for cities/towns.
+Jurisdiction naming: `county-{slug}.json` for counties, `place-{slug}.json` for cities/towns.
+
+### Federal legislators (`open-civics/sc/federal.json`)
+
+Different shape from state/local — these come from the `unitedstates/congress-legislators` dataset rather than the normalized open-civics scrapers, so they do NOT carry the v0.2 structured seat fields:
+
+```ts
+{
+  meta: { state: "SC", level: "federal", lastUpdated: "...", source: "unitedstates/congress-legislators" },
+  senate: {
+    [seatClass: "1" | "2" | "3"]: FederalSenator   // keyed by senate class (staggered terms)
+  },
+  house: {
+    [districtNumber: string]: FederalRep
+  }
+}
+
+interface FederalSenator {
+  name: string;
+  party: "R" | "D";
+  phone: string;
+  website: string;
+  contactForm: string;
+  office: string;                // physical office address — NOT the v0.2 office enum
+  seatClass: "1" | "2" | "3";    // US Senate class (NOT the v0.2 seatClass enum)
+  stateRank: "senior" | "junior";
+  bioguideId: string;
+  source: string;
+  lastUpdated: string;
+}
+
+interface FederalRep {
+  name: string;
+  party: "R" | "D";
+  phone: string;
+  website: string;
+  contactForm: string;
+  office: string;                // physical office address
+  district: string;
+  bioguideId: string;
+  source: string;
+  lastUpdated: string;
+}
+```
+
+⚠ **Name collision warning:** federal records use `office` for the physical office building string ("211 Russell Senate Office Building") and `seatClass` for the US Senate class number ("1" / "2" / "3"). These are NOT the same fields as the v0.2 normalized enums on state/local records. If your code reads federal data, treat it as its own schema — don't try to share validators or display logic between federal and state/local without disambiguation.
 
 ### Boundaries (`open-civics-boundaries/sc/boundaries/*.json`)
 
@@ -68,8 +185,23 @@ Standard GeoJSON FeatureCollections. Each feature has `properties.district` matc
 
 - `sldu.json` — state senate districts (46 features)
 - `sldl.json` — state house districts (124 features)
+- `cd.json` — US congressional districts (7 features, SC only)
+- `state-outline.json` — SC state outline (1 feature, used for US senate matching)
 - `county-{name}.json` — county council districts
 - `place-{name}.json` — city council districts (where available)
+
+## Structured seat fields (v0.2+)
+
+The state/local member shape lifts seat semantics out of free-text `title` into typed fields. Consumers should prefer these for any logic that needs to find or filter by seat.
+
+- **`office`** — what office this person holds. Enum: `state-senator | state-representative | governor | lt-governor | mayor | council-member`. Leadership overlays (chair, vice-chair, mayor pro tem) are NOT offices — they're captured separately.
+- **`leadership`** — leadership role on top of the office, or `null`. Enum: `chair | vice-chair | mayor-pro-tem | null`. A "Chairman of County Council, District 8" is a `council-member` with `leadership: chair` and a seat at `seatId: "8"`.
+- **`seatClass`** — structural class of the seat. `numbered` (specific identifiable seat — District 5, Ward 2, Seat 3), `at-large` (no geographic subdivision), or `unknown` (source didn't publish enough to distinguish).
+- **`seatLabel`** — literal label the jurisdiction uses for numbered seats: `district`, `ward`, or `seat`. `null` for at-large and unknown. Use this for display when you want to render "Ward 3" vs "District 3" correctly.
+- **`seatId`** — the seat's identifier as a string, or `null` for at-large and unknown. For state legislators this equals the dict key (`senate["25"].seatId === "25"`).
+- **`vacant`** — boolean. `true` when the seat exists but is unfilled. Filter on this rather than `name === "Vacant"` — vacancies sometimes include the seat number in the name (e.g., `"Vacant District 5"`).
+- **`seatSource`** — provenance of the structured seat data. `source` = structured upstream field; `parsed-title` = extracted from free-text title; `inferred-registry` = jurisdiction-wide hint applied; `manual` = hand-curated override. Useful for understanding data confidence.
+- **`partisan`** — whether the office is partisan. `true` for state legislators, governor, lt-governor. `false` for most SC local offices (council seats are nonpartisan). `null` for unknown. Distinguishes "no party info" from "no parties at this level".
 
 ## Import examples
 
@@ -78,7 +210,7 @@ Standard GeoJSON FeatureCollections. Each feature has `properties.district` matc
 import scState from 'open-civics/sc/state.json';
 const senator = scState.senate["1"];
 const rep = scState.house["42"];
-const governor = scState.governor;
+const governor = scState.executive.find(m => m.office === "governor");
 
 // All senators as array
 const allSenators = Object.values(scState.senate);
@@ -86,6 +218,18 @@ const allSenators = Object.values(scState.senate);
 // Local councils
 import greenvilleCounty from 'open-civics/sc/local/county-greenville.json';
 const members = greenvilleCounty.members;
+
+// Find the member representing a specific district seat
+const district17Member = members.find(
+  m => m.seatClass === "numbered" && m.seatId === "17"
+);
+
+// Filter out vacancies before showing reps
+const filledSeats = members.filter(m => !m.vacant);
+
+// Federal
+import scFederal from 'open-civics/sc/federal.json';
+const seniorSenator = Object.values(scFederal.senate).find(s => s.stateRank === "senior");
 
 // Boundaries for point-in-polygon lookup
 import senateBoundaries from 'open-civics-boundaries/sc/boundaries/sldu.json';
@@ -126,6 +270,25 @@ function findSenator(lat, lng) {
 }
 ```
 
+To find the local council member for a county-council district:
+
+```js
+import countyBoundaries from 'open-civics-boundaries/sc/boundaries/county-greenville.json';
+import greenvilleCounty from 'open-civics/sc/local/county-greenville.json';
+
+function findCouncilMember(lat, lng) {
+  const point = turf.point([lng, lat]);
+  const districtFeature = countyBoundaries.features.find(f =>
+    turf.booleanPointInPolygon(point, f)
+  );
+  if (!districtFeature) return null;
+  const seatId = districtFeature.properties.district;
+  return greenvilleCounty.members.find(
+    m => m.seatClass === "numbered" && m.seatId === seatId && !m.vacant
+  );
+}
+```
+
 ## Migration checklist
 
 ### 1. Remove existing scraper code
@@ -138,17 +301,22 @@ function findSenator(lat, lng) {
 - Replace all data reads with imports from the packages (see examples above)
 - State legislators: `import scState from 'open-civics/sc/state.json'`
 - Local councils: `import data from 'open-civics/sc/local/{jurisdiction}.json'`
+- Federal: `import scFederal from 'open-civics/sc/federal.json'`
 - Boundaries: `import geo from 'open-civics-boundaries/sc/boundaries/{file}.json'`
 
 ### 3. Adapt to the data shape
 - State data is keyed by district number, not an array — use `Object.values()` if you need arrays
-- Local members are in a `members` array with `name`, `title`, `email`, `phone`
-- Party info is only on state legislators (not local)
-- Some local members may be missing email or phone (the `?` fields above)
+- Local members are in a `members` array
+- Prefer `seatClass`/`seatId` over parsing `title` for seat lookup (`title` is human-readable but variable; the structured fields are normalized)
+- Filter vacancies via `member.vacant === true`, NOT `name === "Vacant"` (vacancies sometimes carry the seat in the name)
+- Render display labels with `seatLabel`: a Ward town like Camden should read "Ward 3" not "District 3"
+- Federal records have their OWN `office` and `seatClass` fields with different semantics (office address; senate class number) — don't share types with state/local
+- Party info is on state legislators, governor/lt-governor, and federal — local offices are nonpartisan (`partisan: false`) and won't carry `party`
 
 ### 4. Update any district lookup logic
 - Replace any server-side geocoding/district lookup with client-side point-in-polygon using the boundary GeoJSON
 - Or keep server-side if you prefer — just import the boundary files there instead
+- Match members to boundary features via `member.seatId === feature.properties.district`
 
 ## Staying up to date
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -120,7 +120,7 @@ interface LocalMember {
   // state
   vacant: boolean;
   seatSource: "source" | "parsed-title" | "inferred-registry" | "manual";
-  partisan: boolean;             // false for most SC local offices
+  partisan: boolean | null;      // false for most SC local offices; null when unknown
 
   // contact
   email?: string;
@@ -309,7 +309,7 @@ function findCouncilMember(lat, lng) {
 - Local members are in a `members` array
 - Prefer `seatClass`/`seatId` over parsing `title` for seat lookup (`title` is human-readable but variable; the structured fields are normalized)
 - Filter vacancies via `member.vacant === true`, NOT `name === "Vacant"` (vacancies sometimes carry the seat in the name)
-- Render display labels with `seatLabel`: a Ward town like Camden should read "Ward 3" not "District 3"
+- Render display labels with `seatLabel`: a ward-based town like Darlington should read "Ward 3" not "District 3" (6 SC cities currently expose `seatLabel: "ward"`: Chester, Darlington, Greenwood, Hilton Head, Rock Hill, Sumter; 2 jurisdictions use `seatLabel: "seat"`: Anderson city and Colleton county)
 - Federal records have their OWN `office` and `seatClass` fields with different semantics (office address; senate class number) — don't share types with state/local
 - Party info is on state legislators, governor/lt-governor, and federal — local offices are nonpartisan (`partisan: false`) and won't carry `party`
 
@@ -375,7 +375,7 @@ Use Dependabot (Option A). It gives you visibility into what changed, lets you r
 
 ## Available jurisdictions
 
-96 local jurisdictions are covered — every SC county and incorporated municipality. Full list of files:
+96 local jurisdictions are covered: all 46 SC counties and 50 of the largest cities/towns. (SC has ~270 incorporated municipalities total — coverage is the largest 50 by population plus targeted additions, not exhaustive.) Full list of files:
 
 https://github.com/TimSimpsonJr/open-civics/tree/master/data/sc/local
 


### PR DESCRIPTION
## Summary

Refreshes `docs/migration-guide.md` for the v0.2 schema introduced in #27. Closes #28.

Key changes:
- New TypeScript-style type definitions for State / Executive / Local / Federal records, with the new structured seat fields (\`office\`, \`leadership\`, \`seatClass\`, \`seatLabel\`, \`seatId\`, \`vacant\`, \`seatSource\`, \`partisan\`) documented per record type
- New "Structured seat fields (v0.2+)" section explaining each field and the four-stage provenance ladder
- Federal data shape now documented separately — flagged the field-name collision (federal \`office\` is an office-building string; federal \`seatClass\` is the US Senate class number "1"/"2"/"3", NOT the normalized enum)
- Migration checklist updated: prefer structured fields over title parsing; use \`member.vacant === true\` instead of \`name === "Vacant"\`; render \`seatLabel\` for Ward/Seat towns
- Boundaries inventory adds \`cd.json\` (congressional) and \`state-outline.json\` (state outline for senate matching)
- New example showing county-council member lookup via \`seatId === feature.properties.district\`

## Test plan

- [ ] No code changes; doc-only
- [ ] Render the guide on GitHub to check formatting
- [ ] Confirm field definitions match the actual published shape in \`open-civics@0.2.1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)