### PR TITLE
fix(ci): make data-update PRs trigger validation + auto-merge

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -35,6 +35,13 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          # PAT (or GitHub App token) so the data-update PR is opened by a
+          # non-GITHUB_TOKEN identity. PRs opened with the default GITHUB_TOKEN
+          # do NOT trigger other workflows (validate.yml), so auto-merge never
+          # fires. Falls back to GITHUB_TOKEN if SCRAPER_PAT is unset — the PR is
+          # still created, but won't validate/auto-merge until the secret exists.
+          token: ${{ secrets.SCRAPER_PAT || secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
@@ -112,7 +119,8 @@ jobs:
 
       - name: Create PR if data changed
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Must match the checkout token above so the PR triggers validate.yml.
+          GH_TOKEN: ${{ secrets.SCRAPER_PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -e
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,10 +1,11 @@
 name: Validate Data
 
 on:
+  # No paths filter: validation must run on every PR so that (a) branch
+  # protection's required "validate" check is always reported, and (b) a PR
+  # whose latest commit is docs-only can't skip the gate. pytest + validate.py
+  # are fast, so running them on all PRs is cheap.
   pull_request:
-    paths:
-      - 'data/**'
-      - 'registry.json'
 
 jobs:
   validate:

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -73,8 +73,8 @@ open-civics/
 ├── pytest.ini                     # Pytest configuration
 │
 ├── .github/workflows/
-│   ├── scrape.yml                 # Weekly/monthly scraper run → data-update/* PR + reporting
-│   ├── validate.yml               # PR check on data/** changes + auto-merge for data-update/* PRs
+│   ├── scrape.yml                 # Weekly/monthly scraper run → data-update/* PR (opened via SCRAPER_PAT) + reporting
+│   ├── validate.yml               # PR check (pytest + validate.py) on every PR + auto-merge for data-update/* PRs
 │   └── publish.yml                # Weekly npm publish (both packages) if data changed since last tag
 │
 └── docs/                          # Documentation, audits, and plans
@@ -89,6 +89,7 @@ open-civics/
 - `TableAdapter` auto-detects column roles from header text (name, title, email, phone, district, department)
 - `scrape.yml` runs scrapers with `--report`, then `diff_summary.py`, `stale_check.py`, and `quality_report.py` enrich the PR body
 - `validate.yml` auto-merges `data-update/*` PRs after validation passes
+- Auto-merge chain: `scrape.yml` opens the PR via `secrets.SCRAPER_PAT` (the default GITHUB_TOKEN can't trigger workflows) → `validate.yml` runs → master branch protection's required `validate` check + repo `allow_auto_merge` let a green check merge it
 - `publish.yml` publishes both npm packages from the same repo using `package.json` and `boundaries-package.json`
 - `dataHash` and `dataLastChanged` in local JSON meta blocks track actual data changes vs re-scrapes
 - All three workflows create GitHub Issues on failure (label: `ci-failure`)


### PR DESCRIPTION
Fixes the stuck `data-update` PR pipeline (16 had piled up since mid-March). Three root causes, all addressed:

## Root causes

1. **PRs opened with `GITHUB_TOKEN` don't trigger workflows.** `scrape.yml` created the data-update PR using the default `GITHUB_TOKEN`, so `validate.yml` (and the auto-merge job inside it) never ran. → Open the PR with `secrets.SCRAPER_PAT`, falling back to `GITHUB_TOKEN` if the secret is unset.
2. **`validate.yml`'s `paths` filter could skip the gate.** A PR whose evaluated commit didn't touch `data/**` or `registry.json` got no `validate` check at all — which also makes it unusable as a required status check. → Drop the filter; `pytest` + `validate.py` are fast enough to run on every PR.
3. **`allow_auto_merge` was disabled at the repo level**, so `gh pr merge --auto` would have failed regardless. → Enabled via API (separate from this diff).

## In this PR
- `scrape.yml`: checkout + PR creation use `secrets.SCRAPER_PAT || secrets.GITHUB_TOKEN`
- `validate.yml`: removed the `paths` filter
- `MANIFEST.md`: refreshed workflow descriptions + documented the auto-merge chain

## Manual step required (one-time)
For auto-merge to actually fire, add a repo secret **`SCRAPER_PAT`** — a fine-grained PAT scoped to this repo with **Contents: read/write** and **Pull requests: read/write**. Until then the workflow falls back to `GITHUB_TOKEN` (PRs created but not validated/auto-merged — current behavior, no regression). A GitHub App token via `actions/create-github-app-token` is the no-expiry alternative.

## Applied via API alongside this PR
- `allow_auto_merge = true`, `delete_branch_on_merge = true`
- Branch protection on `master` requiring the `validate` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
