### PR TITLE
fix(ci): publish version-bump push bypasses branch protection (SCRAPER_PAT)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # Push the version-bump commit + tag as the repo owner (SCRAPER_PAT) so
+          # it bypasses master branch protection's required "validate" check. That
+          # check only runs on PRs, so a direct version-bump push has no passing
+          # check and a GITHUB_TOKEN push (github-actions[bot], not an admin) would
+          # be rejected. The owner's PAT is exempt because enforce_admins=false.
+          token: ${{ secrets.SCRAPER_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
The branch protection added in #44 (required `validate` check on master) blocks the publish workflow's direct version-bump push to master — required status checks reject direct pushes by `github-actions[bot]`. The next publish would ship to npm but fail at the commit/tag step, leaving master out of sync (and the following run stuck re-publishing the same version).

**Fix:** push the version bump + tag as the repo owner via `SCRAPER_PAT` (admin bypass, since `enforce_admins=false`), mirroring `scrape.yml`.

**Separately:** the original #41 publish failures were npm `EOTP` (2FA/OTP required on publish), not token expiry — already resolved by using an Automation `NPM_TOKEN` (06-08 publish succeeded). This PR only addresses the push-blocking regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)